### PR TITLE
Create state-of-the-practice.md

### DIFF
--- a/state-of-the-practice.md
+++ b/state-of-the-practice.md
@@ -1,0 +1,83 @@
+Below are a collection of policy and technical resources related to the handling and protection of MDS and other types of mobility data. They are provided here to aid cities in developing their own policies around data privacy, security, and transparency. 
+
+## Privacy Principles and Policies
+
+Policy documents related to the privacy implications of mobility data collection, storage, and use.
+
+-   Los Angeles DOT: [Los Angeles DOT Data Protection Principles](https://ladot.io/wp-content/uploads/2019/03/LADOT_Data_Protection_Principles-1.pdf)
+
+-   City of Minneapolis: [Privacy Principles [DRAFT]](http://www.minneapolismn.gov/www/groups/public/@council/documents/webcontent/data-privacy-principles.pdf)
+
+-   City of Seattle: [Mobility Data Privacy and Handling Guidelines](https://www.seattle.gov/Documents/Departments/SDOT/NewMobilityProgram/Mobility_Data_Guidelines_01142020.pdf) / [Privacy Principles](https://www.seattle.gov/Documents/Departments/InformationTechnology/City-of-Seattle-Privacy-Principles-FINAL.pdf)
+
+-   NACTO: [Guidelines for Managing Mobility Data](https://nacto.org/managingmobilitydata/)
+
+-   Mobility Data Collaborative: [Guidelines for Mobility Data Sharing Governance and Contracting](https://saemobilus.sae.org/content/MDC00001202004/)
+
+-   EU Joint Research Center: [Guidelines for public administrations on location privacy](https://joinup.ec.europa.eu/sites/default/files/news/attachment/jrc103110_1-dc246-d3.2_eulf_guideline_on_location_privacy_v1.00_final_-_pubsy.pdf)
+
+## Data Processing, Aggregation, and Anonymization
+
+Methodologies and tools for ingesting, aggregating, and anonymizing mobility data.
+
+-   City of Minneapolis: [Mobility Data Methodology and Analysis](http://www.minneapolismn.gov/www/groups/public/@publicworks/documents/webcontent/wcmsp-218311.pdf)
+
+-   City of Austin: [Dockless Data API](https://github.com/cityofaustin/atd-dockless-api)
+
+-   City of Santa Monica: [MDS Provider Toolkit](https://github.com/CityofSantaMonica/mds-provider/tree/master/mds)
+
+-   City of Louisville: [Open Data Publishing Methodology](https://github.com/louisvillemetro-innovation/dockless-open-data)
+
+-   City of Chicago: [How Chicago Protects Privacy in TNP and Taxi Open Data](http://dev.cityofchicago.org/open%20data/data%20portal/2019/04/12/tnp-taxi-privacy.html)
+
+-   SharedStreets: [Mobility Metrics](https://github.com/sharedstreets/mobility-metrics)
+
+-   Stae: [Open Data Publisher](https://support.municipal.systems/hc/en-us/articles/360048160613-Publishing-MDS-Derived-Fuzzed-Trip-Data-as-Open-Data-while-Protecting-Rider-Privacy)
+
+## Risk Assessment
+
+Toolkits and resources for understanding and managing risk associated with mobility data.
+
+-   Future of Privacy Forum:  [Privacy Risk Assessment for Smart and Connected Communities](https://drive.google.com/open?id=1-G0Hy9LWh-oeth1VMEba8pE91BTnr2oH)
+
+-   Open Data Institute: [Data Ethics Canvas](https://docs.google.com/document/d/1ug4Cc0BLn7XkvGVSC5YR_M8dU_nq4kA3a0rWVeiiars/edit)
+
+## Public Data Sharing
+
+Open / public mobility data sets, and information about approaches to anonymization.
+
+**Binning, fuzzing**
+
+-   City of Louisville: [Dockless Vehicle Trips](https://data.louisvilleky.gov/dataset/dockless-vehicles) (plus k-anonymity)
+
+-   City of Kansas City, MO: [Microtransit (Scooter and Ebike) Trips](https://data.kcmo.org/Transportation/Microtransit-Scooter-and-Ebike-Trips/dy5n-ewk5) 
+
+- City of Calgary, Alberta: [Shared Mobility Pilot Trips](https://data.calgary.ca/browse?q=shared%20mobility%20pilot&sortBy=relevance)
+
+**Census tracts**
+
+-   City of Austin: [Shared Micromobility Vehicle Trips](https://data.austintexas.gov/Transportation-and-Mobility/Shared-Micromobility-Vehicle-Trips/7d8e-dm7r) 
+
+-   City of Chicago: [E-Scooter Trips](https://data.cityofchicago.org/Transportation/E-Scooter-Trips-2019-Pilot/2kfw-zvte) 
+
+**Street segments**
+
+-   City of Minneapolis: [Motorized Foot Scooter Trips](http://opendata.minneapolismn.gov/datasets/motorized-foot-scooter-trips-2018#__sid=js2) 
+
+## Data Visualization
+
+Public-facing mobility data visualization and reporting tools.
+
+-   City of Louisville: [Dockless Vehicle Origin & Destination Map](https://cdolabs-admin.carto.com/builder/f57ee92e-09c3-4efd-b7c0-3d561cc9e951/embed)
+
+-   City of Austin: [Micromobility Data Explorer](https://github.com/cityofaustin/atd-dockless-dataviz) / [Micromobility Program Reporting Dashboard](https://data.mobility.austin.gov/micromobility-data/)
+
+-   City of Kansas City, MO: [Scooter & E-Bike Heatmap](https://data.kcmo.org/Transportation/Scooter-E-Bike-Heatmap-end-trips-/44zy-nsnr) 
+
+## Outreach and education
+
+Resources for public education and outreach related to mobility data and privacy.
+
+-   Future of Privacy Forum: [Shedding Light on Smart City Privacy](https://fpf.org/wp-content/uploads/2017/03/smart-cities-infographic_updated.png)
+
+NOTE: The links above are provided for reference and do not represent an endorsement or official policy statement of the Open Mobility Foundation.


### PR DESCRIPTION
Per discussion with committee voting members, we'd like to move the State of Practice from this repo's Wiki to a file in the repository. This will allow community members to more easily propose changes and see version history.

Note that this file is identical to what is currently in [the wiki](https://github.com/openmobilityfoundation/privacy-committee/wiki/Mobility-Data-Management-State-of-Practice).